### PR TITLE
Fix error when Source isn't a string

### DIFF
--- a/XAMLMarkupExtensions/Binding/DynBindingExtension.cs
+++ b/XAMLMarkupExtensions/Binding/DynBindingExtension.cs
@@ -98,7 +98,7 @@ namespace XAMLMarkupExtensions.Binding
             Binding binding = new Binding();
             object src = source;
 
-            if ((src == null) || (".".CompareTo(src) == 0))
+            if ((src == null) || ((src is string) && (".".CompareTo(src) == 0)))
             {
                 if (obj is FrameworkElement)
                     src = ((FrameworkElement)obj).DataContext;


### PR DESCRIPTION
Normal bindings can have any kind of object as their source, tried it with this one and got ArgumentException. I fixed the line that was causing this